### PR TITLE
feat(registry): append-only fetch ticker + version-aware idempotency

### DIFF
--- a/lib/registry_install.sh
+++ b/lib/registry_install.sh
@@ -111,7 +111,11 @@ registry_fetch_all() {
   __sb_workdir=$2
   mkdir -p "$__sb_workdir"
 
-  log "Registry: fetching upstream binaries in parallel"
+  # POSIX word-count via positional params (function-local; safe to clobber).
+  # shellcheck disable=SC2086  # word splitting on $__sb_tools is the goal
+  set -- $__sb_tools
+  __sb_total=$#
+  log "Registry: fetching upstream binaries in parallel ($__sb_total tools)"
   for __sb_t in $__sb_tools; do
     __sb_url=$(_reg_url "$__sb_t")
     if [ -z "$__sb_url" ]; then
@@ -136,6 +140,43 @@ registry_fetch_all() {
       fi
     ) &
   done
+
+  # Progress ticker: append-only history with cumulative bytes downloaded.
+  # Poll the per-tool .status files (already written by the backgrounds
+  # above) so the operator sees fetches landing rather than ~2 minutes of
+  # silence behind the bare wait. Each tick is a plain line so the operator
+  # can scroll back through the throughput trace; we suppress consecutive
+  # ticks where __sb_done hasn't moved so the log doesn't spam.
+  __sb_prev_done=-1
+  while :; do
+    __sb_done=$(find "$__sb_workdir" -maxdepth 1 -name '*.status' 2> /dev/null | wc -l | tr -d ' ')
+    __sb_kb=$(du -sk "$__sb_workdir" 2> /dev/null | awk '{print $1}')
+    __sb_mb=$(awk -v k="${__sb_kb:-0}" 'BEGIN { printf "%.1f", k/1024 }')
+    if [ "$__sb_done" -ge "$__sb_total" ]; then
+      printf '    fetched %2d/%d  %6s MB — done\n' \
+        "$__sb_done" "$__sb_total" "$__sb_mb"
+      break
+    fi
+    if [ "$__sb_done" != "$__sb_prev_done" ]; then
+      # In-flight list, capped at 8 names to keep the line scannable.
+      __sb_inflight=""
+      __sb_n=0
+      for __sb_t in $__sb_tools; do
+        [ -e "$__sb_workdir/$__sb_t.status" ] && continue
+        __sb_n=$((__sb_n + 1))
+        if [ "$__sb_n" -le 8 ]; then
+          __sb_inflight="$__sb_inflight $__sb_t"
+        elif [ "$__sb_n" = 9 ]; then
+          __sb_inflight="$__sb_inflight ..."
+        fi
+      done
+      printf '    fetched %2d/%d  %6s MB — in-flight:%s\n' \
+        "$__sb_done" "$__sb_total" "$__sb_mb" "$__sb_inflight"
+      __sb_prev_done=$__sb_done
+    fi
+    sleep 2
+  done
+
   wait
   # Summary line per tool so the operator can see what happened.
   for __sb_t in $__sb_tools; do
@@ -198,18 +239,46 @@ _reg_install_one() {
   __sb_t=$1
   __sb_workdir=$2
 
-  # Idempotency: if our INSTALL_AS file already exists AND the smoke test
-  # passes, skip extract+install. We deliberately check the target path,
-  # not just `command -v`, because a distro pkg may have provided the
-  # binary at /usr/bin/ — we still want OUR pinned version at
+  # Idempotency, version-aware. We deliberately check the target path
+  # (INSTALL_AS), not just `command -v`, because a distro pkg may have
+  # provided the binary at /usr/bin/ — we still want OUR pinned version at
   # /usr/local/bin/ to shadow it. Symlinks are re-applied either way.
+  #
+  # Only skip when the installed version actually matches the pinned
+  # version — otherwise fall through and reinstall, which the install
+  # step (`install -m 0755 ...` further down) handles atomically over the
+  # existing binary. Without this, bumping a *_VERSION in registry.sh has
+  # no effect on hosts where the binary already exists at the old pin.
+  # Version-less tools (VERSION_PATTERN=skip, e.g. gron) keep the
+  # presence-only short-circuit, since `--version` can't distinguish.
   __sb_smoke=$(_reg_field "$__sb_t" SMOKE)
   __sb_install_as=$(_reg_field "$__sb_t" INSTALL_AS)
-  if [ -e "$__sb_install_as" ] && [ -n "$__sb_smoke" ] &&
-    sh -c "$__sb_smoke" > /dev/null 2>&1; then
-    log "  $__sb_t: already installed; skipping (ensuring symlinks)"
-    _reg_apply_symlinks "$__sb_t"
-    return 0
+  __sb_pinned=$(_reg_field "$__sb_t" VERSION)
+  __sb_pattern=$(_reg_field "$__sb_t" VERSION_PATTERN)
+  [ -n "$__sb_pattern" ] || __sb_pattern='[0-9][0-9]*\.[0-9][0-9]*\(\.[0-9][0-9]*\)*'
+  if [ -e "$__sb_install_as" ] && [ -n "$__sb_smoke" ]; then
+    if [ "$__sb_pattern" = skip ]; then
+      if sh -c "$__sb_smoke" > /dev/null 2>&1; then
+        log "  $__sb_t: already installed; skipping (ensuring symlinks)"
+        _reg_apply_symlinks "$__sb_t"
+        return 0
+      fi
+    else
+      __sb_idem_rc=0
+      __sb_idem_out=$(sh -c "$__sb_smoke" 2>&1) || __sb_idem_rc=$?
+      if [ "$__sb_idem_rc" = 0 ]; then
+        __sb_idem_actual=$(printf '%s\n' "$__sb_idem_out" | grep -o "$__sb_pattern" | head -n 1)
+        if [ -n "$__sb_idem_actual" ] && [ "$__sb_idem_actual" = "$__sb_pinned" ]; then
+          log "  $__sb_t: already at pinned $__sb_pinned; skipping"
+          _reg_apply_symlinks "$__sb_t"
+          return 0
+        fi
+        if [ -n "$__sb_idem_actual" ]; then
+          log "  $__sb_t: installed=$__sb_idem_actual pinned=$__sb_pinned — upgrading"
+        fi
+      fi
+      # smoke rc != 0 OR version mismatch OR unparseable → fall through.
+    fi
   fi
 
   __sb_statusfile="$__sb_workdir/$__sb_t.status"

--- a/lib/registry_install.sh
+++ b/lib/registry_install.sh
@@ -116,6 +116,12 @@ registry_fetch_all() {
   set -- $__sb_tools
   __sb_total=$#
   log "Registry: fetching upstream binaries in parallel ($__sb_total tools)"
+  # Collect each curl-subshell PID so we can `wait` on the curls only.
+  # Bare `wait` blocks on ALL backgrounded children — including the sudo
+  # keepalive subshell that install.sh spawns when sudo needs a password
+  # (`( while true; do sudo -n true; sleep 50; done ) &`). Targeted wait
+  # ignores it; the EXIT trap (install.sh:_stop_sudo_keepalive) reaps it.
+  __sb_pids=""
   for __sb_t in $__sb_tools; do
     __sb_url=$(_reg_url "$__sb_t")
     if [ -z "$__sb_url" ]; then
@@ -139,6 +145,7 @@ registry_fetch_all() {
         printf 'fetch_failed\n%s\n' "$__sb_url" > "$__sb_workdir/$__sb_t.status"
       fi
     ) &
+    __sb_pids="$__sb_pids $!"
   done
 
   # Progress ticker: append-only history with cumulative bytes downloaded.
@@ -177,7 +184,8 @@ registry_fetch_all() {
     sleep 2
   done
 
-  wait
+  # shellcheck disable=SC2086  # intentional word splitting on the PID list
+  wait $__sb_pids
   # Summary line per tool so the operator can see what happened.
   for __sb_t in $__sb_tools; do
     __sb_status=$(head -n 1 "$__sb_workdir/$__sb_t.status" 2> /dev/null)

--- a/lib/registry_install.sh
+++ b/lib/registry_install.sh
@@ -265,15 +265,23 @@ _reg_install_one() {
   __sb_pattern=$(_reg_field "$__sb_t" VERSION_PATTERN)
   [ -n "$__sb_pattern" ] || __sb_pattern='[0-9][0-9]*\.[0-9][0-9]*\(\.[0-9][0-9]*\)*'
   if [ -e "$__sb_install_as" ] && [ -n "$__sb_smoke" ]; then
+    # Smoke against INSTALL_AS's directory first in PATH — otherwise a
+    # user-local copy earlier in PATH (cargo, ~/.local/bin, ~/.fzf/bin)
+    # would report its own version and falsely cause "upgrade" loops.
+    __sb_idem_dir=""
+    case "$__sb_install_as" in
+      */*) __sb_idem_dir=$(dirname -- "$__sb_install_as") ;;
+    esac
+    __sb_idem_path="${__sb_idem_dir:+$__sb_idem_dir:}$PATH"
     if [ "$__sb_pattern" = skip ]; then
-      if sh -c "$__sb_smoke" > /dev/null 2>&1; then
+      if PATH="$__sb_idem_path" sh -c "$__sb_smoke" > /dev/null 2>&1; then
         log "  $__sb_t: already installed; skipping (ensuring symlinks)"
         _reg_apply_symlinks "$__sb_t"
         return 0
       fi
     else
       __sb_idem_rc=0
-      __sb_idem_out=$(sh -c "$__sb_smoke" 2>&1) || __sb_idem_rc=$?
+      __sb_idem_out=$(PATH="$__sb_idem_path" sh -c "$__sb_smoke" 2>&1) || __sb_idem_rc=$?
       if [ "$__sb_idem_rc" = 0 ]; then
         __sb_idem_actual=$(printf '%s\n' "$__sb_idem_out" | grep -o "$__sb_pattern" | head -n 1)
         if [ -n "$__sb_idem_actual" ] && [ "$__sb_idem_actual" = "$__sb_pinned" ]; then

--- a/lib/registry_verify.sh
+++ b/lib/registry_verify.sh
@@ -24,13 +24,39 @@ registry_verify_all() {
   __sb_pass=0
   __sb_fail=0
   __sb_rows=""
+  __sb_shadows=""
 
   for __sb_t in $__sb_tools; do
     __sb_total=$((__sb_total + 1))
     __sb_expected=$(_reg_field "$__sb_t" VERSION)
     __sb_smoke=$(_reg_field "$__sb_t" SMOKE)
+    __sb_install_as=$(_reg_field "$__sb_t" INSTALL_AS)
     __sb_pattern=$(_reg_field "$__sb_t" VERSION_PATTERN)
     [ -n "$__sb_pattern" ] || __sb_pattern='[0-9][0-9]*\.[0-9][0-9]*\(\.[0-9][0-9]*\)*'
+
+    # Always run the smoke with INSTALL_AS's dir first in PATH. We want to
+    # test what we actually installed; without this, a user-local copy
+    # earlier in PATH (eg ~/.local/bin/fd from cargo, ~/.fzf/bin/fzf from
+    # the upstream install script) is what gets tested and a perfectly
+    # good install reports as "drift". PATH shadowing is surfaced
+    # separately below so the operator can see *that* it's happening.
+    __sb_smoke_dir=""
+    case "$__sb_install_as" in
+      */*) __sb_smoke_dir=$(dirname -- "$__sb_install_as") ;;
+    esac
+    __sb_smoke_path="${__sb_smoke_dir:+$__sb_smoke_dir:}$PATH"
+
+    # Shadow check (informational): if the bare binary name resolves to a
+    # path other than INSTALL_AS, the user's shell will run a different
+    # copy than the one we just installed. Often legitimate (cargo-installed
+    # fd, ~/.fzf install) — never silent.
+    __sb_smoke_bin=$(printf '%s' "$__sb_smoke" | awk '{print $1}')
+    if [ -n "$__sb_smoke_bin" ] && [ -n "$__sb_install_as" ]; then
+      __sb_resolved=$(command -v "$__sb_smoke_bin" 2> /dev/null || true)
+      if [ -n "$__sb_resolved" ] && [ "$__sb_resolved" != "$__sb_install_as" ]; then
+        __sb_shadows="$__sb_shadows  $__sb_smoke_bin: shadowed in PATH by $__sb_resolved (installed at $__sb_install_as)\n"
+      fi
+    fi
 
     if [ -z "$__sb_smoke" ]; then
       __sb_rows="$__sb_rows$(printf '  %-12s expected %-10s no SMOKE defined  -' \
@@ -43,7 +69,7 @@ registry_verify_all() {
     # (gron's --version literally prints "gron version dev"). Trust the
     # URL — if smoke passed and INSTALL_AS exists, we got what we asked for.
     if [ "$__sb_pattern" = skip ]; then
-      if sh -c "$__sb_smoke" > /dev/null 2>&1; then
+      if PATH="$__sb_smoke_path" sh -c "$__sb_smoke" > /dev/null 2>&1; then
         __sb_rows="$__sb_rows$(printf '  %-12s expected %-10s smoke ok (no ver) ✓' \
           "$__sb_t" "$__sb_expected")\n"
         __sb_pass=$((__sb_pass + 1))
@@ -64,7 +90,7 @@ registry_verify_all() {
     # `|| __sb_rc=$?` keeps the failure rc without tripping `set -e` in
     # busybox ash (which exits the parent on `var=$(failing)`).
     __sb_rc=0
-    __sb_out=$(sh -c "$__sb_smoke" 2>&1) || __sb_rc=$?
+    __sb_out=$(PATH="$__sb_smoke_path" sh -c "$__sb_smoke" 2>&1) || __sb_rc=$?
     if [ "$__sb_rc" -ne 0 ]; then
       __sb_rows="$__sb_rows$(printf '  %-12s expected %-10s smoke FAILED (rc=%d) ✗' \
         "$__sb_t" "$__sb_expected" "$__sb_rc")\n"
@@ -92,6 +118,12 @@ registry_verify_all() {
   echo "==> Post-install verification:"
   printf '%b' "$__sb_rows"
   printf '==> %d/%d tools at pinned version\n' "$__sb_pass" "$__sb_total"
+  if [ -n "$__sb_shadows" ]; then
+    echo
+    warn "PATH shadowing detected — your shell will run these copies, not ours:"
+    printf '%b' "$__sb_shadows" >&2
+    warn "Fix by reordering PATH (put /usr/local/bin first) or removing the shadows."
+  fi
 
   if [ "$__sb_fail" -gt 0 ] && [ "${SHELL_BLING_STRICT_VERSIONS:-0}" = 1 ]; then
     err "Version mismatch and SHELL_BLING_STRICT_VERSIONS=1 — failing install"


### PR DESCRIPTION
## Summary

Two operator-facing fixes in `lib/registry_install.sh`, surfaced by a live install on a Debian 12 host:

- **`registry_fetch_all`** — append-only progress ticker. The parallel curl phase used to print one header and then go silent for 1–3 minutes. Now every 2 s we emit a line like `    fetched 12/24   31.5 MB — in-flight: helix lazygit lnav neovim qsv ...` (cumulative bytes via `du -sk`, in-flight list capped at 8 names + ellipsis, ticks suppressed when count hasn't moved). History is preserved — no `\r` rewriting.
- **`_reg_install_one`** — version-aware idempotency. The previous check skipped any tool whose `INSTALL_AS` already existed and whose `--version` exited 0, so a pre-installed (or previously-pinned) binary made the registry a no-op on that host. Bumping e.g. `FD_VERSION` from 8.6.0 → 10.4.2 silently didn't upgrade. Now we parse the installed version with the same `VERSION_PATTERN` regex `registry_verify_all` uses, compare against the pinned `${TOOL}_VERSION`, and only skip on an exact match. Mismatch logs `installed=X pinned=Y — upgrading` and falls through to the existing fetch → hash-verify → sig-verify → `install -m 0755` path (which atomically overwrites). Version-less tools (`VERSION_PATTERN=skip`, e.g. gron) retain the presence-only fast path.

## Test plan

- [x] `sh -n lib/registry_install.sh` — syntax clean.
- [x] `shellcheck -s sh` — no new findings (only the pre-existing SC2249).
- [x] `pre-commit run` — all hooks pass.
- [ ] Live re-run on the Debian 12 host that hit both issues; expect the ticker to print MB-rising history lines and the verification table to show `fd 10.4.2 / fzf 0.72.0 / lazygit 0.61.1 / starship 1.25.1 / zoxide 0.9.9` with explicit `installed=X pinned=Y — upgrading` lines for each above.
- [ ] Second run on the same host: every tool short-circuits at `already at pinned X.Y.Z; skipping`.
- [ ] Bump submodule pin in `shell-bling-ubuntu-test-harness` and let Jenkins #55 run the full 30-distro Docker + 5-distro VM matrix.